### PR TITLE
Monkey patch TemplateHandlers::Base.call to support Rails 6.1

### DIFF
--- a/lib/prawnto/template_handlers/base.rb
+++ b/lib/prawnto/template_handlers/base.rb
@@ -5,7 +5,7 @@ module Prawnto
     class Base < (base_class_for_template_handler_required? ? ::ActionView::TemplateHandler : ::Object)
       include ::ActionView::TemplateHandlers::Compilable if template_should_include_compilable?
 
-      def self.call(template)
+      def self.call(template, _source=nil)
         "_prawnto_compile_setup;" +
         "pdf = Prawn::Document.new(@prawnto_options[:prawn]);" +
         "#{template.source}\n" +
@@ -20,5 +20,3 @@ module Prawnto
     end
   end
 end
-
-

--- a/lib/prawnto/template_handlers/dsl.rb
+++ b/lib/prawnto/template_handlers/dsl.rb
@@ -1,7 +1,7 @@
 module Prawnto
   module TemplateHandlers
     class Dsl < Base
-      def self.call(template)
+      def self.call(template, _source = nil)
         <<-RUBY
           _prawnto_compile_setup(true)
           pdf = Prawn::Document.new(@prawnto_options[:prawn])
@@ -14,5 +14,3 @@ module Prawnto
     end
   end
 end
-
-

--- a/lib/prawnto/template_handlers/raw.rb
+++ b/lib/prawnto/template_handlers/raw.rb
@@ -1,7 +1,7 @@
 module Prawnto
   module TemplateHandlers
     class Raw < Base
-      def self.call(template)
+      def self.call(template, _source = nil)
         #TODO: what's up with filename here?  not used is it?
         source,filename = massage_template_source(template)
         "_prawnto_compile_setup;" +
@@ -37,7 +37,7 @@ module Prawnto
         source = template.source.dup
         variable_name = '_pdf'
         filename = nil
-        
+
         source.gsub! /^(\s*?)(\$LOAD_PATH)/, '\1#\2'
         source.gsub! /^(\s*?)(require\(?\s*['"]rubygems['"]\s*\)?\s*)$/, '\1#\2'
         source.gsub! /^(\s*?)(require\(?\s*['"]prawn['"]\s*\)?\s*)$/, '\1#\2'


### PR DESCRIPTION
Rails 6.1 send the template source as 2nd argument to Template Handler#call
Prawnto gets the template source internally, it doesn't need the argument.
This change fixes argument arity for Rails 6.1